### PR TITLE
Update hot-water-cylinder.yaml

### DIFF
--- a/hot-water-cylinder.yaml
+++ b/hot-water-cylinder.yaml
@@ -67,7 +67,7 @@ time:
         - logger.log: "Synchronized system clock"
     on_time:
 
-      - seconds: 0
+      - seconds: /15
         minutes: 0
         then:
         - lambda: |-
@@ -76,7 +76,7 @@ time:
             deviceTimeTm.tm_isdst = 0; // DST taken care of in deviceTimeIso
             time_t deviceTimeTime = mktime(&deviceTimeTm); // Normalse time after modification
             ESPTime deviceTimeEspTime = ESPTime::from_c_tm(&deviceTimeTm, deviceTimeTime);
-            if (deviceTimeEspTime.hour == id(runtimeCatchupEndHour).state) {
+            if ( std::round(float(deviceTimeEspTime.hour)) == std::round(float(id(runtimeCatchupEndHour).state)) ) {
             	id(runtimeMinutes) = 0;
             }
         - component.update: runtime
@@ -276,7 +276,7 @@ binary_sensor:
     name: "Heating"
     id: heating
     lambda: |-
-      return (id(power).state > 50);
+      return (id(power).state > 200);
   
   - platform: template
     name: "Time Synchronised"


### PR DESCRIPTION
 - Fix issues with the runtime not resetting at the set end time by dealing with floating point error, and also trigger it 4 times instead of once.
 -  Increase the heating sensor trigger wattage. The HWC rarely and very briefly spikes to around 100W causing a false trigger.